### PR TITLE
確認画面部分を別コンポーネントに分離

### DIFF
--- a/src/components/ConfirmModal.vue
+++ b/src/components/ConfirmModal.vue
@@ -1,0 +1,96 @@
+<template>
+  <div>
+    <div
+      v-if="isOpenConfirm"
+      class="confirmBackLayer"
+      @click="$emit('click')"
+    />
+    <div v-if="isOpenConfirm" class="confirmOverLayer">
+      <div class="confirmText">
+        <slot />
+      </div>
+      <ul class="confirmList">
+        <li class="confirmItem">
+          <ActionButton
+            theme="primary"
+            size="L"
+            text="はい"
+            @click="handlePositiveButtonClick"
+          />
+        </li>
+        <li class="confirmItem">
+          <ActionButton
+            theme="disable"
+            size="L"
+            text="いいえ"
+            @click="handleNegativeButtonClick"
+          />
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import ActionButton from '@/components/ActionButton.vue'
+
+export default Vue.extend({
+  components: {
+    ActionButton
+  },
+  props: {
+    isOpenConfirm: {
+      type: Boolean,
+      default: false
+    }
+  },
+  methods: {
+    handlePositiveButtonClick() {
+      this.$emit('click')
+      this.$emit('click-positive')
+    },
+    handleNegativeButtonClick() {
+      this.$emit('click')
+      this.$emit('click-negative')
+    }
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.confirmBackLayer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: $bg-black;
+  opacity: 0.7;
+  z-index: 2;
+}
+.confirmOverLayer {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 80%;
+  max-width: 320px;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
+  border-radius: 10px;
+  background-color: $white;
+  padding: 20px 16px 0 16px;
+  z-index: 3;
+}
+.confirmText {
+  font-size: 20px;
+}
+.confirmList {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.confirmItem {
+  flex: 0 0 48%;
+}
+</style>

--- a/src/components/ConfirmModal.vue
+++ b/src/components/ConfirmModal.vue
@@ -1,11 +1,7 @@
 <template>
   <div>
-    <div
-      v-if="isOpenConfirm"
-      class="confirmBackLayer"
-      @click="$emit('click')"
-    />
-    <div v-if="isOpenConfirm" class="confirmOverLayer">
+    <div v-if="isOpen" class="confirmBackLayer" @click="$emit('click')" />
+    <div v-if="isOpen" class="confirmOverLayer">
       <div class="confirmText">
         <slot />
       </div>
@@ -40,7 +36,7 @@ export default Vue.extend({
     ActionButton
   },
   props: {
-    isOpenConfirm: {
+    isOpen: {
       type: Boolean,
       default: false
     }

--- a/src/components/FooterButtons.vue
+++ b/src/components/FooterButtons.vue
@@ -17,7 +17,7 @@
       </li>
     </ul>
     <ConfirmModal
-      :is-open-confirm="isOpenConfirm"
+      :is-open="isOpenConfirm"
       @click="isOpenConfirm = false"
       @click-positive="openTel(number)"
       @click-negative="isOpenConfirm = false"

--- a/src/components/FooterButtons.vue
+++ b/src/components/FooterButtons.vue
@@ -16,39 +16,21 @@
         救急要請(119)
       </li>
     </ul>
-    <div
-      v-if="isOpenConfirm"
-      class="confirmBackLayer"
+    <ConfirmModal
+      :is-open-confirm="isOpenConfirm"
       @click="isOpenConfirm = false"
-    />
-    <div v-if="isOpenConfirm" class="confirmOverLayer">
-      <p class="confirmText">{{ confirmText }}</p>
-      <ul class="confirmList">
-        <li class="confirmItem">
-          <ActionButton
-            theme="primary"
-            size="L"
-            text="はい"
-            @click="openTel(number)"
-          />
-        </li>
-        <li class="confirmItem">
-          <ActionButton
-            theme="disable"
-            size="L"
-            text="いいえ"
-            @click="isOpenConfirm = false"
-          />
-        </li>
-      </ul>
-    </div>
+      @click-positive="openTel(number)"
+      @click-negative="isOpenConfirm = false"
+    >
+      {{ confirmText }}
+    </ConfirmModal>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
 import PhoneIcon from '@/assets/images/icon-phone.svg'
-import ActionButton from '@/components/ActionButton.vue'
+import ConfirmModal from '@/components/ConfirmModal.vue'
 
 interface PhoneItem {
   destination: string
@@ -71,7 +53,7 @@ type Methods = {
 export default Vue.extend<Data, Methods, unknown, unknown>({
   components: {
     PhoneIcon,
-    ActionButton
+    ConfirmModal
   },
   data() {
     return {
@@ -140,39 +122,5 @@ export default Vue.extend<Data, Methods, unknown, unknown>({
   &.emergency {
     background-color: $error;
   }
-}
-.confirmBackLayer {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: $bg-black;
-  opacity: 0.8;
-  z-index: 2;
-}
-.confirmOverLayer {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 80%;
-  max-width: 300px;
-  border: 1px solid $error;
-  border-radius: 8px;
-  background-color: $white;
-  padding: 16px;
-  z-index: 3;
-}
-.confirmText {
-  font-size: 20px;
-}
-.confirmList {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-.confirmItem {
-  flex: 0 0 48%;
 }
 </style>

--- a/src/views/Record.vue
+++ b/src/views/Record.vue
@@ -28,7 +28,6 @@
           name="spo2"
           label="酸素飽和度(SpO2)"
           unit="％"
-          :step="0.1"
           :value="inputSpo2"
           @input="inputSpo2 = $event"
         />


### PR DESCRIPTION
close #3 

- 確認画面部分を `src/components/FooterButtons.vue` から分離し、別コンポーネントとしました。
- スタイルを微修正しました。

![スクリーンショット 2021-01-11 13 04 48](https://user-images.githubusercontent.com/14883063/104146791-498aae00-540f-11eb-9425-690b31dd1302.png)
