### PR TITLE
ログインページを作成

### DIFF
--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -1,6 +1,11 @@
 :root {
-  box-sizing: border-box;
   color: #2b2b2b;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 body {

--- a/src/components/ActionButton.vue
+++ b/src/components/ActionButton.vue
@@ -45,7 +45,7 @@ export default class ActionButton extends Vue {
 
 <style lang="scss" scoped>
 .actionButton {
-  display: block;
+  display: inline-block;
   width: 100%;
   font-weight: bold;
   padding: 0.8em 1em;
@@ -53,9 +53,9 @@ export default class ActionButton extends Vue {
   border: none;
   color: $white;
   cursor: pointer;
+  text-align: center;
   text-decoration: none;
   &.inline {
-    display: inline-block;
     width: auto;
   }
   &-primary {

--- a/src/components/ListOrGraphSwitch.vue
+++ b/src/components/ListOrGraphSwitch.vue
@@ -70,8 +70,8 @@ export default Vue.extend({
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: 48px;
+  height: 48px;
   padding: 8px;
   color: $white;
   background-color: $gray-1;

--- a/src/components/ToggleSwitch.vue
+++ b/src/components/ToggleSwitch.vue
@@ -59,8 +59,8 @@ export default Vue.extend({
     content: '';
   }
   &::before {
-    width: 2.6em;
-    height: 1.2em;
+    width: 2.8em;
+    height: 1.6em;
     border-radius: 3em;
     background: $gray-4;
     padding: 3px;
@@ -83,7 +83,7 @@ export default Vue.extend({
         background: $primary;
       }
       &::after {
-        left: calc(2.6em - 1.2em + 4px);
+        left: calc(2.8em - 1.6em + 4px);
       }
     }
   }

--- a/src/components/VCheckbox.vue
+++ b/src/components/VCheckbox.vue
@@ -1,0 +1,80 @@
+<template>
+  <div>
+    <input
+      :id="name"
+      class="checkbox"
+      type="checkbox"
+      :checked="checked"
+      :value="value"
+      @input="$emit('input', $event.target.checked, $event.target.value)"
+    />
+    <label :for="name" class="label">
+      <slot />
+    </label>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  model: {
+    prop: 'checked',
+    event: 'input'
+  },
+  props: {
+    name: {
+      type: String,
+      required: true
+    },
+    checked: {
+      type: Boolean,
+      default: false
+    },
+    value: {
+      type: String,
+      default: ''
+    }
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.checkbox {
+  display: none;
+  ~ .label {
+    display: flex;
+    align-items: center;
+    position: relative;
+    padding-left: 30px;
+    cursor: pointer;
+    &::before {
+      position: absolute;
+      left: 5px;
+      border: 1px solid $gray-2;
+      border-radius: 3px;
+      content: '';
+      display: block;
+      height: 18px;
+      width: 18px;
+    }
+    &::after {
+      position: absolute;
+      top: 50%;
+      left: 11px;
+      border-right: 3px solid $primary;
+      border-bottom: 3px solid $primary;
+      content: '';
+      display: block;
+      width: 6px;
+      height: 12px;
+      margin-top: -7px;
+      transform: rotate(45deg);
+      opacity: 0;
+    }
+  }
+  &:checked + label::after {
+    opacity: 1;
+  }
+}
+</style>

--- a/src/router/guarded-routes.ts
+++ b/src/router/guarded-routes.ts
@@ -1,0 +1,47 @@
+import { RouteConfig } from 'vue-router'
+import Record from '@/views/Record.vue'
+import Registered from '@/views/Registered.vue'
+import History from '@/views/History.vue'
+import Detail from '@/views/Detail.vue'
+
+const guardedRoutes: Array<RouteConfig> = [
+  {
+    path: '/record',
+    name: 'Record',
+    component: Record
+  },
+  {
+    path: '/registered',
+    name: 'Registered',
+    component: Registered
+  },
+  {
+    path: '/history',
+    name: 'History',
+    component: History
+  },
+  {
+    path: '/detail/:statusId',
+    name: 'Detail',
+    component: Detail
+  }
+  // {
+  //   path: '/about',
+  //   name: 'About',
+  //   // route level code-splitting
+  //   // this generates a separate chunk (about.[hash].js) for this route
+  //   // which is lazy-loaded when the route is visited.
+  //   component: () =>
+  //     import(/* webpackChunkName: "about" */ '../views/About.vue')
+  // }
+]
+
+guardedRoutes.forEach((routeObject, index) => {
+  Object.assign(guardedRoutes[index], {
+    meta: {
+      requiresAuth: false // 認証のAPIと繋げたあとにtrueにする
+    }
+  })
+})
+
+export default guardedRoutes

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,54 +1,24 @@
 import Vue from 'vue'
-import VueRouter, { RouteConfig } from 'vue-router'
-import Home from '../views/Home.vue'
-import Record from '@/views/Record.vue'
-import Registered from '@/views/Registered.vue'
-import History from '@/views/History.vue'
-import Detail from '@/views/Detail.vue'
+import VueRouter from 'vue-router'
+import guardedRoutes from '@/router/guarded-routes'
+import nonGuardedRoutes from '@/router/non-guarded-routes'
 
 Vue.use(VueRouter)
 
-const routes: Array<RouteConfig> = [
-  {
-    path: '/',
-    name: 'Home',
-    component: Home
-  },
-  {
-    path: '/record',
-    name: 'Record',
-    component: Record
-  },
-  {
-    path: '/registered',
-    name: 'Registered',
-    component: Registered
-  },
-  {
-    path: '/history',
-    name: 'History',
-    component: History
-  },
-  {
-    path: '/detail/:statusId',
-    name: 'Detail',
-    component: Detail
-  }
-  // {
-  //   path: '/about',
-  //   name: 'About',
-  //   // route level code-splitting
-  //   // this generates a separate chunk (about.[hash].js) for this route
-  //   // which is lazy-loaded when the route is visited.
-  //   component: () =>
-  //     import(/* webpackChunkName: "about" */ '../views/About.vue')
-  // }
-]
-
 const router = new VueRouter({
   mode: 'history',
-  base: process.env.BASE_URL,
-  routes
+  base: process.env.BASE_URL
+})
+
+router.addRoutes(guardedRoutes)
+router.addRoutes(nonGuardedRoutes)
+
+router.beforeEach((to, from, next) => {
+  if (to.matched.some(record => record.meta.requiresAuth)) {
+    next({ name: 'login' })
+  } else {
+    next()
+  }
 })
 
 export default router

--- a/src/router/non-guarded-routes.ts
+++ b/src/router/non-guarded-routes.ts
@@ -1,0 +1,18 @@
+import { RouteConfig } from 'vue-router'
+import Home from '@/views/Home.vue'
+import Login from '@/views/Login.vue'
+
+const nonGuardedRoutes: Array<RouteConfig> = [
+  {
+    path: '/',
+    name: 'Home',
+    component: Home
+  },
+  {
+    path: '/login',
+    name: 'Login',
+    component: Login
+  }
+]
+
+export default nonGuardedRoutes

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -20,6 +20,7 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 .title {
+  font-size: 24px;
   text-align: center;
 }
 </style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,18 +1,25 @@
 <template>
-  <div class="home">
-    <img alt="Vue logo" src="../assets/logo.png" />
-    <HelloWorld msg="Welcome to Your Vue.js + TypeScript App" />
+  <div>
+    <h1 class="title">仮）遠隔モニタリングシステム</h1>
+    <ActionButton size="L" theme="primary" to="/login">
+      ログイン
+    </ActionButton>
   </div>
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'vue-property-decorator'
-import HelloWorld from '@/components/HelloWorld.vue' // @ is an alias to /src
+import Vue from 'vue'
+import ActionButton from '@/components/ActionButton.vue'
 
-@Component({
+export default Vue.extend({
   components: {
-    HelloWorld
+    ActionButton
   }
 })
-export default class Home extends Vue {}
 </script>
+
+<style lang="scss" scoped>
+.title {
+  text-align: center;
+}
+</style>

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1,0 +1,75 @@
+<template>
+  <div>
+    <h1 class="title">ログイン</h1>
+    <InputField
+      label="ログインID"
+      name="loginId"
+      :value="inputLoginId"
+      @input="inputLoginId = $event"
+    />
+    <InputField
+      label="パスワード"
+      type="password"
+      name="password"
+      :value="inputPassword"
+      @input="inputPassword = $event"
+    />
+    <div class="right">
+      <router-link to="/terms">
+        パスワードを忘れた場合
+      </router-link>
+    </div>
+    <div class="margin">
+      <router-link to="/terms">
+        利用規約を読む
+      </router-link>
+    </div>
+    <div class="margin">
+      <VCheckbox name="agree" v-model="agree">
+        利用規約に同意する
+      </VCheckbox>
+    </div>
+    <ActionButton size="L" theme="primary" @click="handleLogin">
+      ログイン
+    </ActionButton>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import ActionButton from '@/components/ActionButton.vue'
+import InputField from '@/components/InputField.vue'
+import VCheckbox from '@/components/VCheckbox.vue'
+
+export default Vue.extend({
+  components: {
+    ActionButton,
+    InputField,
+    VCheckbox
+  },
+  data() {
+    return {
+      inputLoginId: '',
+      inputPassword: '',
+      agree: false
+    }
+  },
+  methods: {
+    handleLogin() {
+      this.$router.push({ name: 'Record' })
+    }
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.title {
+  text-align: center;
+}
+.margin {
+  margin: 30px 0;
+}
+.right {
+  text-align: right;
+}
+</style>


### PR DESCRIPTION
close #9 

- ログインページとフロントページを追加しました。
- 認証ありとなしのページでルーティングのファイルを分けました。
- UIパーツのcssを見直しました。

![スクリーンショット 2021-01-17 13 45 18](https://user-images.githubusercontent.com/14883063/104831281-bea42a80-58ca-11eb-8900-f18c0bea8580.png)
