### PR TITLE
入力完了画面のメッセージ切り替え

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="message" :class="`type${messageType}`">
+    <slot />
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  props: {
+    isError: {
+      type: Boolean,
+      default: false
+    }
+  },
+  computed: {
+    messageType() {
+      return this.isError ? 'Error' : 'Normal'
+    }
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.message {
+  border-radius: 10px;
+  margin: 16px 0;
+  padding: 16px;
+}
+.typeNormal {
+  background-color: $alert-normal;
+}
+.typeError {
+  background-color: $alert-error;
+  font-weight: bold;
+}
+</style>

--- a/src/views/Registered.vue
+++ b/src/views/Registered.vue
@@ -9,7 +9,13 @@
       </ActionButton>
     </div>
     <h1>{{ date }}</h1>
-    <div class="message">体調記録を登録しました</div>
+    <Message v-if="isError" is-error>
+      症状の悪化がみられます。<br />
+      必ず保健所に電話してください。
+    </Message>
+    <Message v-else>
+      体調記録を登録しました。
+    </Message>
     <StatusInfo :status="status" />
     <DeleteRecord :status-id="status.statusId" />
     <FooterButtons />
@@ -24,6 +30,7 @@ import ActionButton from '@/components/ActionButton.vue'
 import StatusInfo from '@/components/StatusInfo.vue'
 import DeleteRecord from '@/components/DeleteRecord.vue'
 import FooterButtons from '@/components/FooterButtons.vue'
+import Message from '@/components/Message.vue'
 
 export default Vue.extend({
   components: {
@@ -31,7 +38,8 @@ export default Vue.extend({
     ActionButton,
     StatusInfo,
     DeleteRecord,
-    FooterButtons
+    FooterButtons,
+    Message
   },
   data() {
     return {
@@ -60,6 +68,9 @@ export default Vue.extend({
       get(): string {
         return dayjs(this.status.created).format('YYYY/MM/DD HH:mm')
       }
+    },
+    isError() {
+      return false // TODO: statusIdによって切り替える
     }
   }
 })
@@ -70,11 +81,5 @@ export default Vue.extend({
   display: flex;
   justify-content: space-between;
   align-items: center;
-}
-.message {
-  background-color: $alert-normal;
-  border-radius: 10px;
-  margin: 16px 0;
-  padding: 16px;
 }
 </style>


### PR DESCRIPTION
#14 
- Messageコンポーネント実装
- `isError` によるメッセージの出しわけ
  - 仮実装。API実装後に `statusId` を元に出し分ける

正常値: 
<img width="150" alt="スクリーンショット 2021-01-23 16 09 57" src="https://user-images.githubusercontent.com/35390466/105571698-8b174380-5d95-11eb-82b4-584f70586eef.png">
異常値:
<img width="150" alt="スクリーンショット 2021-01-23 16 10 17" src="https://user-images.githubusercontent.com/35390466/105571701-8d799d80-5d95-11eb-8b44-8b39e7b2d519.png">
