### PR TITLE
inputフィールドにpatternを設定

### DIFF
--- a/src/components/VInputField.vue
+++ b/src/components/VInputField.vue
@@ -6,6 +6,7 @@
         :class="{ 'inputField-error': showError }"
         :style="{ fontSize: fontSizeMap.get(fontSize) }"
         :type="type"
+        :pattern="type === 'number' ? '\d*' : null"
         :name="name"
         :placeholder="placeholder"
         :step="step"

--- a/src/components/VInputField.vue
+++ b/src/components/VInputField.vue
@@ -6,7 +6,7 @@
         :class="{ 'inputField-error': showError }"
         :style="{ fontSize: fontSizeMap.get(fontSize) }"
         :type="type"
-        :pattern="type === 'number' ? '\d*' : null"
+        :pattern="type === 'number' ? '\\d*' : null"
         :name="name"
         :placeholder="placeholder"
         :step="step"


### PR DESCRIPTION
close #59 

`type` が `number` のときにpatternを設定し、数字キーボードを表示するようにしました。

iPhone12の場合↓
<img src="https://user-images.githubusercontent.com/14883063/109470197-745dbe00-7ab2-11eb-8a85-754f76b618cb.PNG" width="250" />