### PR TITLE
typoとhtmlタグの不具合を修正

### DIFF
--- a/src/components/InputNumberField.vue
+++ b/src/components/InputNumberField.vue
@@ -1,9 +1,10 @@
 <template>
-  <validation-provider :name="name" :rules="rules">
-    <label class="inputFieldContainer">
-      <span class="labelText">{{ label }}</span>
+  <validation-provider :name="name" :rules="rules" tag="div">
+    <div class="inputFieldContainer">
+      <label :for="id" class="labelText">{{ label }}</label>
       <VInputField
         type="number"
+        :id="id"
         :name="name"
         :placeholder="placeholder"
         :step="step"
@@ -13,7 +14,7 @@
         :floating-point="floatingPoint"
         @input="$emit('input', $event.target.value)"
       />
-    </label>
+    </div>
   </validation-provider>
 </template>
 
@@ -26,6 +27,9 @@ import { Component, Prop, Vue } from 'vue-property-decorator'
   },
 })
 export default class InputNumberField extends Vue {
+  @Prop({ type: String, default: '' })
+  id: string | undefined
+
   @Prop({ type: String, default: '' })
   rules: string | undefined
 

--- a/src/components/InputTextField.vue
+++ b/src/components/InputTextField.vue
@@ -1,9 +1,10 @@
 <template>
-  <validation-provider :name="name" :rules="rules">
+  <validation-provider :name="name" :rules="rules" tag="div">
     <div slot-scope="ProviderProps">
-      <label class="inputFieldContainer">
-        <span class="labelText">{{ label }}</span>
+      <div class="inputFieldContainer">
+        <label :for="id" class="labelText">{{ label }}</label>
         <VInputField
+          :id="id"
           :type="type"
           :name="name"
           :placeholder="placeholder"
@@ -12,8 +13,8 @@
           :autocomplete="autocomplete"
           @input="$emit('input', $event.target.value)"
         />
-        <span class="error">{{ ProviderProps.errors[0] }}</span>
-      </label>
+      </div>
+      <span class="error">{{ ProviderProps.errors[0] }}</span>
     </div>
   </validation-provider>
 </template>
@@ -27,6 +28,9 @@ import { Component, Prop, Vue } from 'vue-property-decorator'
   },
 })
 export default class VeeInputTextField extends Vue {
+  @Prop({ type: String, default: '' })
+  id: string | undefined
+
   @Prop({ type: String, default: '' })
   rules: string | undefined
 

--- a/src/components/VInputField.vue
+++ b/src/components/VInputField.vue
@@ -3,6 +3,7 @@
     <div class="inputFieldControl">
       <input
         class="inputField"
+        :id="id"
         :class="{ 'inputField-error': showError }"
         :style="{ fontSize: fontSizeMap.get(fontSize) }"
         :type="type"
@@ -34,6 +35,10 @@ type FontSizeType = string
 
 export default Vue.extend({
   props: {
+    id: {
+      type: String,
+      default: '',
+    },
     value: {
       type: String,
       default: '',
@@ -156,6 +161,9 @@ export default Vue.extend({
     &:focus {
       outline-color: $error;
     }
+  }
+  &::placeholder {
+    color: $gray-2;
   }
 }
 .labelText {

--- a/src/components/VeeInputTextField.vue
+++ b/src/components/VeeInputTextField.vue
@@ -1,7 +1,7 @@
 <template>
-  <validation-provider :name="name" :rules="rules">
+  <validation-provider :name="name" :rules="rules" tag="div">
     <div slot-scope="ProviderProps">
-      <label for="username" class="inputFieldContainer">
+      <label class="inputFieldContainer">
         <span class="labelText">{{ label }}</span>
         <input
           :v-model="username"
@@ -10,10 +10,9 @@
           :name="name"
           :placeholder="placeholder"
           :value="value"
-          font-size="S"
         />
-        <p class="error">{{ ProviderProps.errors[0] }}</p>
       </label>
+      <p class="error">{{ ProviderProps.errors[0] }}</p>
     </div>
   </validation-provider>
 </template>

--- a/src/store/modules/statuses.module.ts
+++ b/src/store/modules/statuses.module.ts
@@ -34,9 +34,9 @@ class Statuses extends VuexModule {
   @Action({ rawError: true })
   load(): Promise<Status[]> {
     return UserService.getStatuses().then(
-      (stasuses) => {
-        this.context.commit('loadSuccess', stasuses)
-        return Promise.resolve(stasuses)
+      (statuses) => {
+        this.context.commit('loadSuccess', statuses)
+        return Promise.resolve(statuses)
       },
       (error) => {
         this.context.commit('loginFailure')

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -6,6 +6,7 @@
         {{ message }}
       </div>
       <InputTextField
+        id="username"
         label="ユーザ名"
         name="username"
         value="inputLoginId"
@@ -13,6 +14,7 @@
         rules="required"
       />
       <InputTextField
+        id="password"
         label="パスワード"
         rules="required"
         name="password"

--- a/src/views/Record.vue
+++ b/src/views/Record.vue
@@ -14,9 +14,11 @@
       <ul class="conditionList">
         <li class="conditionItem">
           <InputNumberField
+            id="temperature"
             name="temperature"
             label="体温"
             unit="℃"
+            placeholder="36.5"
             required
             floating-point
             :step="0.1"
@@ -26,9 +28,11 @@
         </li>
         <li class="conditionItem">
           <InputNumberField
+            id="spo2"
             name="spo2"
             label="酸素飽和度(SpO2)"
             unit="％"
+            placeholder="98"
             required
             v-model="inputSpO2"
             rules="required"
@@ -36,9 +40,11 @@
         </li>
         <li class="conditionItem">
           <InputNumberField
+            id="pulse"
             name="pulse"
             label="脈拍"
             unit="bpm"
+            placeholder="80"
             required
             v-model="inputPulse"
             value="inputPulse"
@@ -63,6 +69,7 @@
           </li>
         </ul>
         <InputTextField
+          id="memo"
           label="上記以外の体調の変化"
           name="memo"
           placeholder="例：昨日の20時ごろから咳が止まらない"
@@ -112,7 +119,7 @@ type SymptomItem = {
 export default class Record extends Vue {
   @Auth.Action
   private signOut!: () => void
-  private mydate = new Date()
+  private myDate = new Date()
   private loading = false
   private message = ''
   symptomItems: SymptomItem[] = [
@@ -137,9 +144,9 @@ export default class Record extends Vue {
       label: 'のどの痛み',
     },
   ]
-  inputSpO2 = '98'
-  inputPulse = '80'
-  inputTemperature = '36.5'
+  inputSpO2 = ''
+  inputPulse = ''
+  inputTemperature = ''
   selectedItems: string[] = []
   get status(): ConsumeStatus {
     return {
@@ -168,7 +175,7 @@ export default class Record extends Vue {
     return this.isSubmittable ? 'primary' : 'disable'
   }
   get date(): string {
-    return dayjs(this.mydate).format('YYYY/MM/DD HH:mm')
+    return dayjs(this.myDate).format('YYYY/MM/DD HH:mm')
   }
   itemSelectControl(checked: boolean, value: string): void {
     this.status.symptom[


### PR DESCRIPTION
- inputフィールド関連で、spanの中にdivやpが入っていたので修正しました。
- placeholderのスタイルを設定しました。
- 体温・SpO2・脈拍にデフォルトで値が入っていたので、空にしてplaceholderにしました。